### PR TITLE
support highlight

### DIFF
--- a/modgv/main.go
+++ b/modgv/main.go
@@ -48,7 +48,7 @@ var printHelp bool
 
 func init() {
 	flag.BoolVar(&printHelp, "h", false, "print helps.")
-	flag.StringVar(&highlights, "H", "", "The packages need high light color, split with comma.")
+	flag.StringVar(&highlights, "H", "", "The modules need highlight, split with comma.")
 }
 
 func main() {
@@ -59,13 +59,13 @@ func main() {
 		usage()
 	}
 
-	highlightPackages := strings.Split(highlights, ",")
-	highlightPackagesMap := make(map[string]bool, len(highlightPackages))
-	for _, pkg := range highlightPackages {
-		highlightPackagesMap[pkg] = true
+	highlightModules := strings.Split(highlights, ",")
+	highlightModulesMap := make(map[string]bool, len(highlightModules))
+	for _, mod := range highlightModules {
+		highlightModulesMap[mod] = true
 	}
 
-	if err := modgv.Render(os.Stdin, os.Stdout, modgv.RenderOptions{HighlightPackages: highlightPackagesMap}); err != nil {
+	if err := modgv.Render(os.Stdin, os.Stdout, modgv.RenderOptions{HighlightModules: highlightModulesMap}); err != nil {
 		exitOnErr(err)
 	}
 }
@@ -81,7 +81,7 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "\n")
 
 	fmt.Fprintf(os.Stderr, "USAGE:\n\n")
-	fmt.Fprintf(os.Stderr, "  go mod graph | %s | dot -Tpng -o graph.png\n\n", appName())
+	fmt.Fprintf(os.Stderr, "  go mod graph [-H some modules need highlight, split with comma.] | %s | dot -Tpng -o graph.png\n\n", appName())
 
 	fmt.Fprintf(os.Stderr, "For each module:\n")
 	fmt.Fprintf(os.Stderr, "  * the node representing the greatest version (i.e., the version ")

--- a/modgv/main.go
+++ b/modgv/main.go
@@ -81,7 +81,7 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "\n")
 
 	fmt.Fprintf(os.Stderr, "USAGE:\n\n")
-	fmt.Fprintf(os.Stderr, "  go mod graph [-H some modules need highlight, split with comma.] | %s | dot -Tpng -o graph.png\n\n", appName())
+	fmt.Fprintf(os.Stderr, "  go mod graph | %s [-H some modules need highlight, split with comma.] | dot -Tpng -o graph.png\n\n", appName())
 
 	fmt.Fprintf(os.Stderr, "For each module:\n")
 	fmt.Fprintf(os.Stderr, "  * the node representing the greatest version (i.e., the version ")

--- a/modgv/main.go
+++ b/modgv/main.go
@@ -43,16 +43,29 @@ crafted with passion by Luca Sepe - https://github.com/lucasepe/modgv`
 )
 
 var version = "0.2.0"
+var highlights = ""
+var printHelp bool
+
+func init() {
+	flag.BoolVar(&printHelp, "h", false, "print helps.")
+	flag.StringVar(&highlights, "H", "", "The packages need high light color, split with comma.")
+}
 
 func main() {
 
 	flag.Usage = usage
 	flag.Parse()
-	if flag.NArg() != 0 {
+	if printHelp {
 		usage()
 	}
 
-	if err := modgv.Render(os.Stdin, os.Stdout); err != nil {
+	highlightPackages := strings.Split(highlights, ",")
+	highlightPackagesMap := make(map[string]bool, len(highlightPackages))
+	for _, pkg := range highlightPackages {
+		highlightPackagesMap[pkg] = true
+	}
+
+	if err := modgv.Render(os.Stdin, os.Stdout, modgv.RenderOptions{HighlightPackages: highlightPackagesMap}); err != nil {
 		exitOnErr(err)
 	}
 }

--- a/render.go
+++ b/render.go
@@ -14,7 +14,7 @@ import (
 )
 
 type RenderOptions struct {
-	HighlightPackages map[string]bool
+	HighlightModules map[string]bool
 }
 
 // Render translates “go mod graph” output taken from
@@ -39,14 +39,14 @@ func Render(in io.Reader, out io.Writer, options RenderOptions) error {
 	coloring(graph, options)
 
 	for _, n := range graph.mvsPicked {
-		if options.HighlightPackages[n] {
+		if options.HighlightModules[n] {
 			fmt.Fprintf(out, "\t%q [fillcolor=\"#ff0000\" label=<%s>];\n", n, textToHTML(n, "#fafafa"))
 		} else {
 			fmt.Fprintf(out, "\t%q [fillcolor=\"#0c5525\" label=<%s>];\n", n, textToHTML(n, "#fafafa"))
 		}
 	}
 	for _, n := range graph.mvsUnpicked {
-		if options.HighlightPackages[n] {
+		if options.HighlightModules[n] {
 			fmt.Fprintf(out, "\t%q [fillcolor=\"#ff0000\" label=<%s>];\n", n, textToHTML(n, "#fafafa"))
 		} else {
 			fmt.Fprintf(out, "\t%q [fillcolor=\"#a3a3a3\" label=<%s>];\n", n, textToHTML(n, "#0e0e0e"))
@@ -59,17 +59,17 @@ func Render(in io.Reader, out io.Writer, options RenderOptions) error {
 	return nil
 }
 
-// coloring highlight all packages that reference package in options.HighlightPackages
+// coloring highlight all packages that reference package in options.HighlightModules
 func coloring(gr *graph, options RenderOptions) {
-	if len(options.HighlightPackages) == 0 {
+	if len(options.HighlightModules) == 0 {
 		return
 	}
 	finished := false
 	for !finished {
 		coloringCnt := 0
 		for _, e := range gr.edges {
-			if options.HighlightPackages[e.to] && !options.HighlightPackages[e.from] {
-				options.HighlightPackages[e.from] = true
+			if options.HighlightModules[e.to] && !options.HighlightModules[e.from] {
+				options.HighlightModules[e.from] = true
 				coloringCnt++
 			}
 		}

--- a/render.go
+++ b/render.go
@@ -13,10 +13,14 @@ import (
 	"github.com/lucasepe/modgv/text"
 )
 
+type RenderOptions struct {
+	HighlightPackages map[string]bool
+}
+
 // Render translates “go mod graph” output taken from
 // the 'in' reader into Graphviz's DOT language, writing
 // to the 'out' writer.
-func Render(in io.Reader, out io.Writer) error {
+func Render(in io.Reader, out io.Writer, options RenderOptions) error {
 	graph, err := convert(in)
 	if err != nil {
 		return err
@@ -32,17 +36,45 @@ func Render(in io.Reader, out io.Writer) error {
 
 	fmt.Fprintf(out, "\t%q [shape=underline style=\"\" fontsize=14 label=<<b>%s</b>>];\n", graph.root, graph.root)
 
+	coloring(graph, options)
+
 	for _, n := range graph.mvsPicked {
-		fmt.Fprintf(out, "\t%q [fillcolor=\"#0c5525\" label=<%s>];\n", n, textToHTML(n, "#fafafa"))
+		if options.HighlightPackages[n] {
+			fmt.Fprintf(out, "\t%q [fillcolor=\"#ff0000\" label=<%s>];\n", n, textToHTML(n, "#fafafa"))
+		} else {
+			fmt.Fprintf(out, "\t%q [fillcolor=\"#0c5525\" label=<%s>];\n", n, textToHTML(n, "#fafafa"))
+		}
 	}
 	for _, n := range graph.mvsUnpicked {
-		fmt.Fprintf(out, "\t%q [fillcolor=\"#a3a3a3\" label=<%s>];\n", n, textToHTML(n, "#0e0e0e"))
+		if options.HighlightPackages[n] {
+			fmt.Fprintf(out, "\t%q [fillcolor=\"#ff0000\" label=<%s>];\n", n, textToHTML(n, "#fafafa"))
+		} else {
+			fmt.Fprintf(out, "\t%q [fillcolor=\"#a3a3a3\" label=<%s>];\n", n, textToHTML(n, "#0e0e0e"))
+		}
 	}
 	out.Write(edgesAsDOT(graph))
 
 	fmt.Fprintf(out, "}\n")
 
 	return nil
+}
+
+// coloring highlight all packages that reference package in options.HighlightPackages
+func coloring(gr *graph, options RenderOptions) {
+	if len(options.HighlightPackages) == 0 {
+		return
+	}
+	finished := false
+	for !finished {
+		coloringCnt := 0
+		for _, e := range gr.edges {
+			if options.HighlightPackages[e.to] && !options.HighlightPackages[e.from] {
+				options.HighlightPackages[e.from] = true
+				coloringCnt++
+			}
+		}
+		finished = coloringCnt == 0
+	}
 }
 
 // edgesAsDOT returns the edges in DOT notation.

--- a/render_test.go
+++ b/render_test.go
@@ -11,7 +11,7 @@ func TestRender(t *testing.T) {
 test.com/A@v1.0.0 test.com/B@v1.2.3
 test.com/B@v1.0.0 test.com/C@v4.5.6
 `))
-	if err := Render(in, out); err != nil {
+	if err := Render(in, out, RenderOptions{HighlightPackages: map[string]bool{}}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/render_test.go
+++ b/render_test.go
@@ -11,7 +11,7 @@ func TestRender(t *testing.T) {
 test.com/A@v1.0.0 test.com/B@v1.2.3
 test.com/B@v1.0.0 test.com/C@v4.5.6
 `))
-	if err := Render(in, out, RenderOptions{HighlightPackages: map[string]bool{}}); err != nil {
+	if err := Render(in, out, RenderOptions{HighlightModules: map[string]bool{}}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Support highlights the dependence path of specified modules. This is useful when doing a dependency analysis for a project which has a large mod graph.